### PR TITLE
Update on compute_driver_gene function and added 3D atlas view + 3D scatter plot

### DIFF
--- a/VIA/core.py
+++ b/VIA/core.py
@@ -2594,11 +2594,15 @@ class VIA:
 
             layout = visual_g.layout_fruchterman_reingold(weights='weight', seed=list_graph_init_pos)
             #layout = visual_g.layout_fruchterman_reingold(weights='weight')
+            layout_3 = visual_g.layout_fruchterman_reingold(weights='weight', seed=list_graph_init_pos, dim=3)
         else:
             layout = visual_g.layout_fruchterman_reingold(weights='weight')
+            layout_3 = visual_g.layout_fruchterman_reingold(weights='weight', dim=3)
         #layout = visual_g.layout_fruchterman_reingold(weights='weight',  seed=np.matrix(layout))  # used to be commented out
 
         self.graph_node_pos = layout.coords
+        self.graph_node_pos_3 = layout_3.coords
+        self.layout_3 = layout_3
         self.layout = layout  # reassign
 
         if (self.embedding is None) & (self.do_compute_embedding == True):

--- a/VIA/core.py
+++ b/VIA/core.py
@@ -2486,7 +2486,10 @@ class VIA:
                 df_graph.at[ii, 'markov_pt'] = markov_hitting_times_ai[ei]
 
             locallytrimmed_g.vs["label"] = df_graph['graph_node_label'].values
-            hitting_times = df_graph['pt'].values
+
+        df_graph['pt'] = df_graph['pt'].fillna(0)  # added oct2024
+        df_graph['markov_pt'] = df_graph['markov_pt'].fillna(0)  # added oct2024
+        hitting_times = df_graph['pt'].values # decreased indentation by 1 level oct2024
 
         self.cluster_adjacency = adjacency_matrix2_ai
         self.hitting_times = hitting_times  # not markov chain simulated

--- a/VIA/plotting_via.py
+++ b/VIA/plotting_via.py
@@ -450,6 +450,110 @@ def plot_scatter(embedding: ndarray, labels: list, cmap='rainbow', s=5, alpha=0.
             )
     return fig, ax
 
+def scatter3d(adata, basis:str, color:str, cmap:str=None, 
+              filename:str=None, frac:float=1.0, random_seed=42,
+              show_interactive:bool=True, s:float=10, alpha:float=0.3, elev:float=30, azim:float=-60):
+    '''
+    Plot 3-dimensional scatter plot on separate windows (if `show == True`). Save the figure by giving a `string` to `filename`.
+    :param adata: Anndata object
+    :param basis: str, Basis in adata.obsm that stores the embedding with 3 or more components
+    :param color: str, Column name in adata.obs used to color the scatter markers
+    :param cmap: str, Default: 'husl', Color map to be used. Given from matplotlib or seaborn color palettes
+    :param filename: str, Provide a name of the plot to be saved to the folder Figures in the current directory
+    :param frac: float, Default:1.0, Subsample the data by a given fraction
+    :param random_seed: int, Seed to set the singleton RandomState instance of numpy.
+    :param show_interactive: bool, Default:True, Plot and show the given 3d scatter plot in a separate interactive window. (For running on notebook)
+    :param s: float, Default:10.0, scatter marker size
+    :param alpha: float, Default:0.3, scatter marker alpha value
+    :param elev: float, Default:30, The elevation angle in degrees rotates the camera above and below the x-y plane, with a positive angle corresponding to a location above the plane.
+    :param azim: float, Default:-60, The azimuthal angle in degrees rotates the camera about the z axis, with a positive angle corresponding to a right-handed rotation. In other words, a positive azimuth rotates the camera about the origin from its location along the +x axis towards the +y axis.
+    '''
+    from mpl_toolkits.mplot3d import Axes3D
+    from matplotlib.colors import ListedColormap
+    
+    np.random.seed(random_seed)
+    orig_backend = matplotlib.get_backend()
+    if show_interactive:
+        matplotlib.use('tkagg')
+    if frac < 1:
+        index = np.random.choice(range(len(adata)), size=int(len(adata)*frac), replace=False)
+        adata = adata[index]
+    color_vector = adata.obs_vector(color)
+    categorical = isinstance(color_vector[0], str)
+    if cmap is None:
+        cmap = 'rainbow' if categorical else 'viridis'
+    
+    # axes instance
+    fig = plt.figure(figsize=(6,6))
+    ax = Axes3D(fig, auto_add_to_figure=False)
+    fig.add_axes(ax)
+
+    # get colormap from seaborn
+    if categorical:
+        colormap = matplotlib.cm.get_cmap(cmap)(np.linspace(0,1,len(color_vector.unique())))
+        colormap = ListedColormap(colormap)
+    else:
+        colormap = matplotlib.cm.get_cmap(cmap)
+
+    if basis in adata.obsm: emb = adata.obsm[basis]
+    elif 'X_'+basis in adata.obsm: emb = adata.obsm['X_'+basis]
+    else: raise ValueError(f'{basis} not in Anndata.obsm. Select from {adata.obsm.keys()}')
+    if not basis.startswith('X_'): basis = 'X_'+basis
+    if emb.shape[1] < 3: raise Exception(f"Embedding {basis} has shape {emb.shape} but expected {(emb.shape[0],3)} or more dimensions.")
+    
+    # plot
+    if categorical:
+        color_unique = list(set(color_vector))
+        if any([not i.isnumeric() for i in color_unique]):
+            color_unique.sort()
+        else:
+            color_unique.sort(key=int)
+        lh_list = []
+        for i, c in enumerate(color_unique):
+            emb_sub = emb[np.where(color_vector==c)[0], :]
+            scatter = ax.scatter(
+                    emb_sub[:,0], 
+                    emb_sub[:,1],
+                    emb_sub[:,2],
+                    s=s,
+                    c=colormap(i), 
+                    label=c,
+                    edgecolors='none',
+                    alpha=alpha
+                    )
+            lh = ax.scatter([], [], [], c=colormap(i), label=c)
+            lh_list.append(lh)
+        plt.legend(handles=lh_list, bbox_to_anchor=(1.1, 1), loc=2, ncol=np.ceil(len(color_unique)/15))
+    else:
+        scatter = ax.scatter(
+            emb[:,0],
+            emb[:,1],
+            emb[:,2], 
+            s=s,
+            c=color_vector, 
+            cmap=colormap,
+            edgecolors='none',
+            alpha=alpha
+            )
+        cbar = plt.colorbar(scatter, pad=0.1, shrink=0.9, location='right')
+        cbar.solids.set(alpha=1)
+    ax.set_xlabel(f'{basis[2:]}1')
+    ax.set_ylabel(f'{basis[2:]}2')
+    ax.set_zlabel(f'{basis[2:]}3')
+    ax.set_xticklabels([])
+    ax.set_yticklabels([])
+    ax.set_zticklabels([])
+    ax.tick_params(color='white')
+    ax.view_init(elev=elev, azim=azim)
+    ax.view_init
+
+    # save
+    if filename is not None:
+        if not filename.endswith('.png'): filename=filename+'.png'
+        plt.savefig(filename, bbox_inches='tight')
+        
+    plt.show(block=True)
+    matplotlib.use(orig_backend)
 
 def _make_knn_embeddedspace(embedding):
     # knn struct built in the embedded space to be used for drawing the lineage trajectories onto the 2D plot
@@ -732,26 +836,32 @@ def via_atlas_emb(via_object=None, X_input: ndarray = None, graph: csr_matrix = 
     from umap.umap_ import find_ab_params, simplicial_set_embedding
     # graph is a csr matrix
     # weight all edges as 1 in order to prevent umap from pruning weaker edges away
-    layout_array = np.zeros(shape=(n_cells, 2))
+    layout_array = np.zeros(shape=(n_cells, n_components))
 
-    if (init_pos == 'via') and (via_object is None):
-        # list of lists [[x,y], [x1,y1], []]
-        if (layout is None) or (cluster_membership is None):
-            print('please provide via object or values for arguments: layout and cluster_membership')
+    if init_pos == 'via':
+        if n_components == 3:
+            if via_object is not None:
+                layout = via_object.graph_node_pos_3
+                cluster_membership = via_object.labels
+            elif (layout is None) or (cluster_membership is None):
+                print('please provide via object or values for arguments: layout and cluster_membership')
+            for i in range(n_cells):
+                layout_array[i, 0] = layout[cluster_membership[i]][0]
+                layout_array[i, 1] = layout[cluster_membership[i]][1]
+                layout_array[i, 2] = layout[cluster_membership[i]][2]
+            init_pos = layout_array
+            print(f'{datetime.now()}\tusing via cluster graph to initialize embedding')
         else:
+            if via_object is not None:
+                layout = via_object.graph_node_pos
+                cluster_membership = via_object.labels
+            elif (layout is None) or (cluster_membership is None):
+                print('please provide via object or values for arguments: layout and cluster_membership')
             for i in range(n_cells):
                 layout_array[i, 0] = layout[cluster_membership[i]][0]
                 layout_array[i, 1] = layout[cluster_membership[i]][1]
             init_pos = layout_array
             print(f'{datetime.now()}\tusing via cluster graph to initialize embedding')
-    elif (init_pos == 'via') and (via_object is not None):
-        layout = via_object.graph_node_pos
-        cluster_membership = via_object.labels
-        for i in range(n_cells):
-            layout_array[i, 0] = layout[cluster_membership[i]][0]
-            layout_array[i, 1] = layout[cluster_membership[i]][1]
-        init_pos = layout_array
-        print(f'{datetime.now()}\tusing via cluster graph to initialize embedding')
     elif init_pos == 'spatial':
         init_pos = layout
     a, b = find_ab_params(spread, min_dist)

--- a/VIA/utils_via.py
+++ b/VIA/utils_via.py
@@ -280,9 +280,8 @@ def pruning_clustergraph(adjacency, global_pruning_std=1, max_outgoing=30, prese
                     for i in range(len(locxy[0])):
                         if comp_labels[locxy[0][i]] != comp_labels[locxy[1][i]]:
                             x, y = locxy[0][i], locxy[1][i]
-
-                    cluster_graph_csr[x, y] = adjacency[x, y]
-                    cluster_graph_csr[y, x] = adjacency[y, x]
+                            cluster_graph_csr[x, y] = adjacency[x, y]
+                            cluster_graph_csr[y, x] = adjacency[y, x]
 
                     n_comp_, comp_labels = connected_components(csgraph=cluster_graph_csr, directed=False,
                                                                 return_labels=True)

--- a/VIA/utils_via.py
+++ b/VIA/utils_via.py
@@ -31,8 +31,7 @@ from matplotlib.animation import FuncAnimation, writers
 
 import graphtools
 from scipy.spatial.distance import pdist, squareform
-from scipy.stats import spearmanr
-from scipy.stats import pearsonr
+from scipy.stats import spearmanr, pearsonr
 from collections import defaultdict
 from tqdm.auto import tqdm
 
@@ -58,11 +57,12 @@ def func_mode(ll):
     # If multiple items are maximal, the function returns the first one encountered.
     return max(set(ll), key=ll.count)
 
-def compute_driver_genes(via_object, gene_exp:pd.DataFrame, lineage:int, clusters:list=None, conf_int:float=0.95, q = 0.05):
+def compute_driver_genes(via_object, gene_exp:pd.DataFrame, lineage:int=None, method='pearson', clusters:list=[], graphpath = True, pt_cutoff:float=1.0, conf_int:float=0.95, q = 0.05):
     '''
-    Compute driver genes of each terminal cell fates using Pearson correlation.
+    Compute driver genes of each terminal cell fates using Pearson correlation of pseudotime and gene expressions.
     :param via_object: via object
     :param gene_exp: Dataframe where columns are features (gene) and rows are single cells
+    :param method: Method to use for correlation analysis from either `'pearson'` or `'spearman'`.
     :param lineage: Terminal cluster number to compute lineage driver 
     :param conf_int: default: 0.95 Confidence interval of correlation 
     :param q: Quantile threshold to select cells based on lineage probility. Used when clusters is not given. 
@@ -71,16 +71,39 @@ def compute_driver_genes(via_object, gene_exp:pd.DataFrame, lineage:int, cluster
     '''
     
     if lineage not in via_object.terminal_clusters:
-        raise KeyError(f"Lineage {lineage} not in terminal clusters {via_object.terminal_clusters}.")
+        raise KeyError(f"Please select a valid lineage from the terminal clusters {via_object.terminal_clusters}.")
+    if method not in ['pearson','spearman']:
+        raise KeyError(f"method must be either \'pearson\' or \'spearman\'.")
     
-    df_bp = pd.DataFrame(via_object.single_cell_bp, index=gene_exp.index, columns=via_object.terminal_clusters)[lineage]
-    
-    cell_mask = []
-    if clusters is None or clusters == []:
+    df = pd.DataFrame(via_object.single_cell_bp, columns=via_object.terminal_clusters)
+    df['pt'] = via_object.single_cell_pt_markov.copy()
+    df['parc'] = via_object.labels.copy()
+
+    # Subset cells by graph component that contains the target terminal cluster
+    graph_comps, graph_comps_labels = connected_components(via_object.csr_full_graph, directed=False)
+    g_comp = 0
+    if graph_comps > 1:
+        g_comp = graph_comps_labels[via_object.labels.index(lineage)]
+        df = df[graph_comps_labels == g_comp]
+        gene_exp = gene_exp[graph_comps_labels == g_comp]
+    root = via_object.root[g_comp]
+
+    fate_probs = df[lineage]
+    pseudotime = df['pt']
+    if len(clusters) > 0:
+        # Cell mask by clusters chosen by user
+        cell_mask = [i in clusters for i in df['parc']]
+    elif graphpath:
+        # Cell mask based on via graph shortest path from root to terminal cluster
+        num_cluster = len(set(via_object.labels))
+        G_orange = ig.Graph(n=num_cluster, edges=via_object.edgelist_maxout,
+                            edge_attrs={'weight': via_object.edgeweights_maxout})
+        path_orange = G_orange.get_shortest_paths(root, to=lineage)[0]
+        cell_mask = np.empty_like(fate_probs).astype(bool)
+        cell_mask = [i in path_orange for i in df['parc']]
+    else:
         # Cell mask based on lineage probability inspired by palantir
         eps=1e-2
-        fate_probs = via_object.single_cell_bp[:,via_object.terminal_clusters.index(lineage)]
-        pseudotime = via_object.single_cell_pt_markov
         idx = np.argsort(pseudotime)
         sorted_fate_probs = fate_probs[idx]
         prob_thresholds = np.empty_like(fate_probs)
@@ -98,25 +121,34 @@ def compute_driver_genes(via_object, gene_exp:pd.DataFrame, lineage:int, cluster
         prob_thresholds = np.maximum.accumulate(prob_thresholds, axis=0)
         cell_mask = np.empty_like(fate_probs).astype(bool)
         cell_mask[idx] = prob_thresholds - eps < sorted_fate_probs
-    else:
-        # Cell mask based on given cluster list
-        cell_mask = [True if i in clusters else False for i in via_object.labels]
 
     # Select cells in given lineage
-    print(f'Selected {sum(cell_mask)} cells for lineage {lineage}')
-    print(f'Cells from clusters {list(sorted(set(np.array(via_object.labels)[cell_mask])))}')
-    df_bp = df_bp[cell_mask]
+    print(f'Selected {sum(cell_mask)} cells for lineage {lineage} from {len(df)} cells in connected graph component')
+    print(f'Cells are from clusters: {list(sorted(set(np.array(via_object.labels)[cell_mask])))}')
     gene_exp = gene_exp[cell_mask]
+    df = df[cell_mask]
+    fate_probs = df[lineage]
+    pseudotime = df['pt']
+    # Set pt above pt_cutoff to 0
+    pseudotime[pseudotime>pt_cutoff] = 0
 
     # Compute pearson correlation
     print(f"Computing driver genes")
-    corr = ['']*gene_exp.shape[1]
+    result = {'corr':['']*gene_exp.shape[1], 'pvalue':['']*gene_exp.shape[1]}
+    if method == 'pearson':
+            result['ci_low'] = ['']*gene_exp.shape[1]
+            result['ci_high'] = ['']*gene_exp.shape[1]
     for i, gene in enumerate(tqdm(gene_exp.columns)):
-        res = pearsonr(gene_exp[gene].values, df_bp.values)
-        conf = res.confidence_interval(conf_int)
-        corr[i] = pd.Series([res.statistic, res.pvalue, conf.low, conf.high], name=gene, 
-                            index=['corr', 'pvalue', 'ci_low', 'ci_high'])
-    df_corr = pd.concat(corr, axis=1).T
+        if method == 'pearson':
+            res = pearsonr(gene_exp[gene].values, pseudotime.values)
+            conf = res.confidence_interval(conf_int)
+            result['ci_low'][i] = conf.low
+            result['ci_high'][i] = conf.high
+        elif method == 'spearman':
+            res = spearmanr(gene_exp[gene].values, pseudotime.values)
+        result['corr'][i] = res.statistic
+        result['pvalue'][i] = res.pvalue
+    df_corr = pd.DataFrame(result, index=gene_exp.columns)
     
     # Remove invalid correlations outside (-1,1)
     df_corr['corr'][df_corr['corr'] < -1] = np.nan
@@ -167,6 +199,7 @@ def get_gene_trend(via_object, marker_lineages: list = [], df_gene_exp=None, n_s
                     xval = np.linspace(min(sc_pt), max_val_pt, 100 * 2)
                     yg = geneGAM.predict(X=xval)
                     df_trends[str(gene_i)] = yg
+                df_trends.index = xval
 
             else:
                 print(


### PR DESCRIPTION
Driver genes computation updates
- Added option to use Pearson or Spearman correlation using parameter `method`
- Compute correlation with pseudo time instead of lineage likelihood
- Added pseudo time threshold to compute driver genes of intermediate state by setting pseudo time to 0 beyond the threshold

3D Atlas view
- Updated atlas embedding computation to compute 3 dimensional embedding
- Added new function `scatter3d()` in `plotting_via.py` to plot 3D scatter plots.

Minor fix to `plot_viagraph` function to plot gene expression of single gene